### PR TITLE
XMFA Formatting, added space after ">"

### DIFF
--- a/src/harvest/LcbList.cpp
+++ b/src/harvest/LcbList.cpp
@@ -1352,7 +1352,7 @@ void LcbList::writeToXmfa(ostream & out, const ReferenceList & referenceList, co
 				currvar = blockVarStart;
 			}
 			
-			out << ">" << r+1 << ":" << start << "-" << end << " ";
+			out << "> " << r+1 << ":" << start << "-" << end << " ";
 			
 			if ( ! region.reverse )
 			{


### PR DESCRIPTION
Parsnp XMFA output is currently not compatible with other XMFA tools (ex. Biopython's AlignIO, PGDSpider's convert format). Simply adding a space after the ">" fixes that.

I have not compiled this to check functionality yet. This is my best guess at the appropriate code modification. I implemented this reformat with a sed replacement and it worked perfectly to allow parsnp XMFA files to be imported into other programs.